### PR TITLE
Import data without MNULFI_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Testing strengths and pitfalls of likelihood-free inference with neural networks on the MassiveNus peak count data set
 
 ## Installing the MnuLFI modules
-set `$MNULFI_DIR` in your bashrc or bash_profile then run 
+Open a terminal in the MnuLFI folder, then run
 ```
 python setup.py install --user 
 ```

--- a/mnulfi/__init__.py
+++ b/mnulfi/__init__.py
@@ -1,3 +1,0 @@
-from . import util as UT
-
-UT.check_env() 

--- a/mnulfi/util.py
+++ b/mnulfi/util.py
@@ -6,12 +6,8 @@ some utility functions
 import os
 
 
-def check_env(): 
-    if os.environ.get('MNULFI_DIR') is None: 
-        raise ValueError("set $MNULFI_DIR in bashrc file!") 
-    return None
-
-
 def dat_dir(): 
-    return os.environ.get('MNULFI_DIR') 
-
+    return os.path.join(
+        os.path.dirname(os.path.dirname(__file__)),
+        "data",
+    )


### PR DESCRIPTION
By manipulating the file path from the [`__file__`](https://stackoverflow.com/questions/9271464/what-does-the-file-variable-mean-do) variable in `data.py`, we can remove the need to set a .bashrc environment variable.

(This also bypasses errors on Windows due to different path separators: `/` vs `\`.)